### PR TITLE
Ignoring google services credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+app/google-services.json


### PR DESCRIPTION
For security reasons, that file must be ignored and not be published into the repository